### PR TITLE
Fixed missing bracket for SSL_CA_CRT_FILENAME.

### DIFF
--- a/image/service/phpldapadmin/assets/apache2/phpldapadmin-ssl.conf
+++ b/image/service/phpldapadmin/assets/apache2/phpldapadmin-ssl.conf
@@ -18,7 +18,7 @@
 
 		SSLCertificateFile    /osixia/phpldapadmin/apache2/ssl/${SSL_CRT_FILENAME}
 		SSLCertificateKeyFile /osixia/phpldapadmin/apache2/ssl/${SSL_KEY_FILENAME}
-		#SSLCACertificateFile /osixia/phpldapadmin/apache2/ssl/${SSL_CA_CRT_FILENAME
+		#SSLCACertificateFile /osixia/phpldapadmin/apache2/ssl/${SSL_CA_CRT_FILENAME}
 
 		<Directory /var/www/phpldapadmin/htdocs >
 			Require all granted


### PR DESCRIPTION
Btw, should that line be commented out?

Signed-off-by: Rob Dumas robdumas@gmail.com
