### PR TITLE
Added option to trust reverse proxy X-Forwarded-Proto header (fixes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ HTTPS :
 - **PHPLDAPADMIN_HTTPS_KEY_FILENAME**: Apache ssl certificate private key filename. Defaults to `phpldapadmin.key`
 - **PHPLDAPADMIN_HTTPS_CA_CRT_FILENAME**: Apache ssl CA certificate filename. Defaults to `ca.crt`
 
+Reverse proxy HTTPS :
+- **PHPLDAPADMIN_TRUST_PROXY_SSL**: Set to `true` to trust X-Forwarded-Proto header
+
 Ldap client TLS/LDAPS :
 
 - **PHPLDAPADMIN_LDAP_CLIENT_TLS**: Enable ldap client tls config, ldap serveur certificate check and set client  certificate. Defaults to `true`

--- a/image/service/phpldapadmin/startup.sh
+++ b/image/service/phpldapadmin/startup.sh
@@ -31,6 +31,13 @@ else
   ln -sf ${CONTAINER_SERVICE_DIR}/phpldapadmin/assets/apache2/http.conf /etc/apache2/sites-available/phpldapadmin.conf
 fi
 
+#
+# Reverse proxy config
+#
+if [ "${PHPLDAPADMIN_TRUST_PROXY_SSL,,}" == "true" ]; then
+  echo 'SetEnvIf X-Forwarded-Proto "^https$" HTTPS=on' > /etc/apache2/mods-enabled/remoteip_ssl.conf
+fi
+
 a2ensite phpldapadmin | log-helper debug
 
 #


### PR DESCRIPTION
This fixes #19. It's also possible to add options to respect X-Client-IP or X-Forwarded-For but I didn't find any real use for that.
