### PR TITLE
Fix PHPLDAPADMIN_LDAP_HOSTS to treat as a valid environment variable.

### DIFF
--- a/image/service/phpldapadmin/startup.sh
+++ b/image/service/phpldapadmin/startup.sh
@@ -110,7 +110,7 @@ if [ ! -e "/var/www/phpldapadmin/config/config.php" ]; then
     }
 
     # phpLDAPadmin config
-    for host in $(complex-bash-env iterate PHPLDAPADMIN_LDAP_HOSTS)
+    for host in $(complex-bash-env iterate $PHPLDAPADMIN_LDAP_HOSTS)
     do
 
       append_to_file "\$servers->newServer('ldap_pla');"


### PR DESCRIPTION
Hi. I found that I set `PHPLDAPADMIN_LDAP_HOSTS` environment variable, but it didn't reflect my setting. I think `image/service/phpldapadmin/startup.sh` doesn't handle the environment variable properly because `$` is missing.

Best Regards,
