### PR TITLE
Added ability to sepcifiy different values for ldap 'host' and 'name'

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ See how to [set your own environment variables](#set-your-own-environment-variab
 
   To convert yaml to python online: http://yaml-online-parser.appspot.com/
 
+  If you would like to skip the display name == hostname element of the above use the **PHPLDAPADMIN_LDAP_HOSTS_FRIENDLY** environmental variable. This then uses the top most name as the display name of the server. You will then need to add host to the yaml within the server section. Note this is a global setting, if you do it for one server, you must do it for all. eg
+  ```yaml
+  - Primary:
+    - server:
+      - host: ldap-master.example.org
+  - Backup:
+    - server:
+      - host: 192.168.0.100
+  ```
+
 Apache :
 - **PHPLDAPADMIN_SERVER_ADMIN**: Server admin email. Defaults to `webmaster@example.org`
 - **PHPLDAPADMIN_SERVER_PATH**: Server path (usefull if behind a reverse proxy). Defaults to `/phpldapadmin`

--- a/image/service/phpldapadmin/startup.sh
+++ b/image/service/phpldapadmin/startup.sh
@@ -119,8 +119,10 @@ if [ ! -e "/var/www/phpldapadmin/config/config.php" ]; then
         hostname=$(complex-bash-env getRowKey "${!host}")
         info=$(complex-bash-env getRowValueVarName "${!host}")
 
+        if [ "${PHPLDAPADMIN_LDAP_HOSTS_FRIENDLY,,}" != "true" ]; then
+          append_to_file "\$servers->setValue('server','host','$hostname');"
+        fi
         append_to_file "\$servers->setValue('server','name','$hostname');"
-        append_to_file "\$servers->setValue('server','host','$hostname');"
         host_info "" "$info"
 
       else


### PR DESCRIPTION
The primary use case for this is Kubernetes where the external and internal names will be different.
Within Kubernetes you address services by <service name>.<name space>.<cluster name> the service name will often include elements related to the deployment.

Eg Externally you might want to use `ldap.example.org` as the friendly name to display to the end user. Within the kubernetes cluster this may be `openldap-master.internal.k8s.example.org` where `openldap-master` is the service name, `internal` is the namespace and `k8s.example.org` is the cluster name