### PR TITLE
Add warning about anonymous volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Example script:
 
 ## Beginner Guide
 
+:warning: | This image uses an anonymous volume (mapped to `/var/www/phpldapadmin`) to persist the resulting configuration transformations. When using this image in a docker compose file, this volume must be removed if the configuration transforms are to be reapplied.
+:---: | :---
+
 ### Use your own phpLDAPadmin config
 This image comes with a phpLDAPadmin config.php file that can be easily customized via environment variables for a quick bootstrap,
 but setting your own config.php is possible. 2 options:


### PR DESCRIPTION
The `Dockerfile` for the image uses an anonymous volume to persist the transformed config. This presents a problem in situations where a compose file is used. Volumes are not destroyed when changes are made to the compose file. This is in turn results in stale configuration. Additionally, it is rather difficult to debug when the configuration doesn't update as expected.