### PR TITLE
Improve readme for TLS connect & public CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ See how to [set your own environment variables](#set-your-own-environment-variab
   ```
   All server configuration are available, just add the needed entries, for example:  
   ```yaml
-  - ldap.example.org:
+  - ldap-starttls.example.org:
     - server:
       - tls: true
       - port: 636
@@ -160,6 +160,7 @@ See how to [set your own environment variables](#set-your-own-environment-variab
       - bind_pass: p0p!
     - auto_number:
       - min: 1000
+  - ldaps://ldap.example.org
   - ldap2.example.org
   - ldap3.example.org
   ```
@@ -231,6 +232,15 @@ Take care to link your environment file to `/container/environment/XX-somedir` (
 This is the best solution if you have a private registry. Please refer to the [Advanced User Guide](#advanced-user-guide) just below.
 
 ## Advanced User Guide
+
+### Use a public certificate (LetEncrypt)
+
+You need to give your public CA certificates
+
+    docker run -p 6443:443 \
+            --env PHPLDAPADMIN_LDAP_HOSTS=ldap.example.com \
+            --volume /etc/ssl/certs/ca-certificates.crt:/container/service/ldap-client/assets/certs/ldap-ca.crt
+            --detach osixia/phpldapadmin:0.9.0
 
 ### Extend osixia/phpldapadmin:0.9.0 image
 


### PR DESCRIPTION
Hi,

I improved the README.md to have PLA works with a openldap with enforced TLS, but with a public certificate configured (like LetEncrypt)

This doesn't really fix https://github.com/osixia/docker-phpLDAPadmin/issues/74, but at least it explains a way to make it work in the readme.

There was two pain points at least :

# StartTLS vs TLS

 the tls example in the README.md uses `{'tls': True, 'port': 636}`. This makes actually connect PLA on port 636, but using the StartTLS method.

=> to fix that, without pathing LPA, the only way I found is using full uri `ldaps://ldap.example.org`. I think such an example should be added in the README.md, and it should make it clearer that StartTLS is used on 'tls': true (bad API design in PLA IMHO) 

# CA certificates bundle

It would make sense for me to use `PHPLDAPADMIN_LDAP_CLIENT_TLS=false`, but I found in that case `/etc/ldap/ldap.conf` points to a non-existing file, and there is no way to use TLS then, as it's not possible to configure the CA certificate (a `TLS_CACERT` config is required in `ldap.conf`).

I found that just overriding the ca certs with volume works, so I added a section.